### PR TITLE
Add role props

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Set `fitFallback` property `true`.
 | width | [`DOMString`](https://heycam.github.io/webidl/#idl-DOMString) | Image width | - | No |
 | height | [`DOMString`](https://heycam.github.io/webidl/#idl-DOMString) | Image height | - | No |
 | alt | String | Alternative text for `<img>` | `""` | No |
+| role | String | WAI-ARIA for `<img>` | - | No |
 | className | String | `className` property for component | `""` | No |
 | flexible | Boolean | Make component fluid | `false` | No |
 | fit | String | CSS `object-fit` property for `<img>` (`contain` or `cover`) | - | No |

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default class SuperImage extends React.Component {
     width       : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     height      : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     alt         : PropTypes.string,
-    role        : PropTypes.string,
+    role        : PropTypes.oneOf(['none', 'presentation']),
     className   : PropTypes.string,
     fit         : PropTypes.oneOf(['contain', 'cover']),
     fitFallback : PropTypes.bool,
@@ -80,6 +80,12 @@ export default class SuperImage extends React.Component {
       .forEach(key => {
         props[key] = this.props[key];
       });
+
+    // If alt is empty, only 'img' is specified as role
+    // @see https://www.w3.org/TR/html-aria/#img-alt
+    if (props.alt && props.role) {
+      props.role = 'img';
+    }
 
     // Render picture element if `sources` property exists
     if (this.props.sources.length > 0) {
@@ -148,7 +154,7 @@ export default class SuperImage extends React.Component {
 
     return (
       <div
-        role={this.props.role || 'img'}
+        role={this.props.alt ? 'img' : (this.props.role || 'img')}
         aria-label={this.props.alt}
         className={this.props.className}
         style={style}

--- a/src/index.js
+++ b/src/index.js
@@ -30,6 +30,7 @@ export default class SuperImage extends React.Component {
     width       : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     height      : PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     alt         : PropTypes.string,
+    role        : PropTypes.string,
     className   : PropTypes.string,
     fit         : PropTypes.oneOf(['contain', 'cover']),
     fitFallback : PropTypes.bool,
@@ -41,6 +42,7 @@ export default class SuperImage extends React.Component {
     width       : null,
     height      : null,
     alt         : '',
+    role        : null,
     className   : '',
     fit         : null,
     fitFallback : false,
@@ -146,7 +148,7 @@ export default class SuperImage extends React.Component {
 
     return (
       <div
-        role="img"
+        role={this.props.role || 'img'}
         aria-label={this.props.alt}
         className={this.props.className}
         style={style}

--- a/test/index.js
+++ b/test/index.js
@@ -42,6 +42,13 @@ describe('SuperImage without fallback', () => {
     assert(!node.hasAttribute('role'));
   });
 
+  it('should have `role="img"` when `alt` it not empty', () => {
+    const superImage = TestUtils.renderIntoDocument(<SuperImage src="" role="presentation" alt="some text" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
+
+    assert.equal(node.getAttribute('role'), 'img');
+  });
+
   it('should have expected `className`', () => {
     const superImage = TestUtils.renderIntoDocument(<SuperImage src="" className="foo" />);
     const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
@@ -151,6 +158,13 @@ describe('SuperImage with fallback', () => {
     const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'div');
 
     assert.equal(node.getAttribute('role'), 'presentation');
+  });
+
+  it('should have `role="img"` when `alt` it not empty', () => {
+    const superImage = TestUtils.renderIntoDocument(<SuperImage fitFallback src="" role="presentation" alt="some text" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'div');
+
+    assert.equal(node.getAttribute('role'), 'img');
   });
 
   it('should have expected `className`', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,20 @@ describe('SuperImage without fallback', () => {
     assert(node.hasAttribute('alt'));
   });
 
+  it('should have expected `role`', () => {
+    const superImage = TestUtils.renderIntoDocument(<SuperImage src="" role="presentation" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
+
+    assert.equal(node.getAttribute('role'), 'presentation');
+  });
+
+  it('should not have expected `role`', () => {
+    const superImage = TestUtils.renderIntoDocument(<SuperImage src="" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
+
+    assert(!node.hasAttribute('role'));
+  });
+
   it('should have expected `className`', () => {
     const superImage = TestUtils.renderIntoDocument(<SuperImage src="" className="foo" />);
     const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
@@ -130,6 +144,13 @@ describe('SuperImage with fallback', () => {
     const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'div');
 
     assert(node.hasAttribute('aria-label'));
+  });
+
+  it('should have expected `role`', () => {
+    const superImage = TestUtils.renderIntoDocument(<SuperImage fitFallback src="" role="presentation" />);
+    const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'div');
+
+    assert.equal(node.getAttribute('role'), 'presentation');
   });
 
   it('should have expected `className`', () => {

--- a/type/index.d.ts
+++ b/type/index.d.ts
@@ -7,6 +7,7 @@ declare namespace SuperImage {
   export interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
     src: string;
     sources?: React.SourceHTMLAttributes<HTMLSourceElement>[];
+    alt?: 'none' | 'presentation';
     fit?: 'contain' | 'cover';
     fitFallback?: boolean;
     flexible?: boolean;

--- a/type/index.d.ts
+++ b/type/index.d.ts
@@ -7,7 +7,8 @@ declare namespace SuperImage {
   export interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
     src: string;
     sources?: React.SourceHTMLAttributes<HTMLSourceElement>[];
-    alt?: 'none' | 'presentation';
+    alt?: string;
+    role?: 'none' | 'presentation';
     fit?: 'contain' | 'cover';
     fitFallback?: boolean;
     flexible?: boolean;


### PR DESCRIPTION
## Description

Added `role` props :smiley:
It's useful when using Presentational `<img>`.

```javascript
<SuperImage
  src="image.png"
  width="160"
  height="90"
  alt="super-image"
  role="presentation"
/>
```

It is reflected in real DOM for the first time with `role` specified.
`null` is specified by default, so` role` is not added to the DOM.

If `roll` is unspecified and fallback is used,` img` is specified as before.


## Note

We have not added a type definition to `type/index.d.ts`.
This is because `role` has already been defined in `React.HTMLAttributes` and we deem it unnecessary.