### PR TITLE
Fix role specification when alt is empty

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -81,10 +81,11 @@ export default class SuperImage extends React.Component {
         props[key] = this.props[key];
       });
 
-    // If alt is empty, only 'img' is specified as role
+    // If `alt` is not empty, `none` or `presentation` can not be specified.
+    // So delete the `role` attribute.
     // @see https://www.w3.org/TR/html-aria/#img-alt
-    if (props.alt && props.role) {
-      props.role = 'img';
+    if (props.alt && props.role !== 'img') {
+      props.role = null;
     }
 
     // Render picture element if `sources` property exists

--- a/test/index.js
+++ b/test/index.js
@@ -42,11 +42,11 @@ describe('SuperImage without fallback', () => {
     assert(!node.hasAttribute('role'));
   });
 
-  it('should have `role="img"` when `alt` it not empty', () => {
+  it('should not have `role="img"` when `alt` is not empty', () => {
     const superImage = TestUtils.renderIntoDocument(<SuperImage src="" role="presentation" alt="some text" />);
     const node = TestUtils.findRenderedDOMComponentWithTag(superImage, 'img');
 
-    assert.equal(node.getAttribute('role'), 'img');
+    assert(!node.hasAttribute('role'));
   });
 
   it('should have expected `className`', () => {


### PR DESCRIPTION
## What I did

Fixed `role` specification when `alt` is not empty, which you pointed out in https://github.com/openfresh/super-image/pull/27#discussion_r160899890 :+1:


## Related

* #27 